### PR TITLE
Configure Yabeda when starting app via Puma CLI

### DIFF
--- a/lib/yabeda/rails/railtie.rb
+++ b/lib/yabeda/rails/railtie.rb
@@ -4,9 +4,17 @@ module Yabeda
   module Rails
     class Railtie < ::Rails::Railtie # :nodoc:
       config.after_initialize do
-        next unless ::Rails.const_defined?(:Server)
+        next unless rails_server? || puma_server?
 
         ::Yabeda::Rails.install!
+      end
+
+      def rails_server?
+        ::Rails.const_defined?(:Server)
+      end
+
+      def puma_server?
+        ::Rails.const_defined?('Puma::CLI')
       end
     end
   end

--- a/lib/yabeda/rails/version.rb
+++ b/lib/yabeda/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module Rails
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Fixes #1 - Should hopefully allow Yabeda to register the necessary metrics when running a Rails app via `puma -C config/puma.rb`.