### PR TITLE
Ensure methods defined before calling with Rails server

### DIFF
--- a/lib/yabeda/rails/railtie.rb
+++ b/lib/yabeda/rails/railtie.rb
@@ -3,18 +3,18 @@
 module Yabeda
   module Rails
     class Railtie < ::Rails::Railtie # :nodoc:
-      config.after_initialize do
-        next unless rails_server? || puma_server?
-
-        ::Yabeda::Rails.install!
-      end
-
       def rails_server?
         ::Rails.const_defined?(:Server)
       end
 
       def puma_server?
         ::Rails.const_defined?('Puma::CLI')
+      end
+
+      config.after_initialize do
+        next unless rails_server? || puma_server?
+
+        ::Yabeda::Rails.install!
       end
     end
   end

--- a/lib/yabeda/rails/version.rb
+++ b/lib/yabeda/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module Rails
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
Sorry, my last pr #2 introduced a bug that meant an app wouldn't install the Railtie correctly with `rails s` because the methods weren't defined before calling them. I didn't catch this because it wasn't an issue with Puma.
🤦‍♂️ - Mea culpa!