### PR TITLE
Add custom tags to existing metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ You always can add support for your app server to [lib/yabeda/rails/railtie.rb](
     end
     ```
 
+## Custom tags
+
+You can add additional tags to the existing metrics by adding custom payload to your controller.
+
+```ruby
+# This block is optional but some adapters (like Prometheus) requires that all tags should be declared in advance
+Yabeda.configure do
+  default_tag :importance, nil
+end
+
+class ApplicationController < ActionController::Base
+  def append_info_to_payload(payload)
+    super
+    { importance: extract_importance(params) }
+  end
+end
+```
+`append_info_to_payload` is a method from [ActionController::Instrumentation](https://api.rubyonrails.org/classes/ActionController/Instrumentation.html#method-i-append_info_to_payload)
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -47,7 +47,7 @@ module Yabeda
               status: event.payload[:status],
               format: event.payload[:format],
               method: event.payload[:method].downcase,
-            }
+            }.merge!(event.payload.slice(*Yabeda.default_tags.keys))
 
             rails_requests_total.increment(labels)
             rails_request_duration.measure(labels, Yabeda::Rails.ms2s(event.duration))


### PR DESCRIPTION
@Envek 
This is a small improvement to use the custom tags on existing metrics for Rails.
This should work well with `append_info_to_payload` from Rails. https://api.rubyonrails.org/classes/ActionController/Instrumentation.html#method-i-append_info_to_payload

I'd like to hear your thoughts on it.

I tested it only with Rails 6.0.3.2.

Best,
