### PR TITLE
Add optional Apdex Target constant (but configurable) gauge

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -47,6 +47,12 @@ module Yabeda
                                  comment: "A histogram of the activerecord execution time.",
                                  tags: %i[controller action status format method]
 
+          if config.apdex_target
+            gauge :apdex_target, unit: :seconds,
+                                 comment: "Tolerable time for Apdex (T value: maximum duration of satisfactory request)"
+            collect { rails_apdex_target.set({}, config.apdex_target) }
+          end
+
           ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
             event = ActiveSupport::Notifications::Event.new(*args)
             labels = {

--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -4,6 +4,7 @@ require "yabeda"
 require "active_support"
 require "rails/railtie"
 require "yabeda/rails/railtie"
+require "yabeda/rails/config"
 
 module Yabeda
   # Minimal set of Rails-specific metrics for using with Yabeda
@@ -26,6 +27,8 @@ module Yabeda
       # rubocop: disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize
       def install!
         Yabeda.configure do
+          config = Config.new
+
           group :rails
 
           counter   :requests_total,   comment: "A counter of the total number of HTTP requests rails processed.",

--- a/lib/yabeda/rails/config.rb
+++ b/lib/yabeda/rails/config.rb
@@ -6,6 +6,8 @@ module Yabeda
   module Rails
     class Config < ::Anyway::Config
       config_name :yabeda_rails
+
+      attr_config :apdex_target
     end
   end
 end

--- a/lib/yabeda/rails/config.rb
+++ b/lib/yabeda/rails/config.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "anyway"
+
+module Yabeda
+  module Rails
+    class Config < ::Anyway::Config
+      config_name :yabeda_rails
+    end
+  end
+end

--- a/yabeda-rails.gemspec
+++ b/yabeda-rails.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
   spec.add_dependency "railties"
   spec.add_dependency "yabeda", "~> 0.8"
 


### PR DESCRIPTION
Fixes #17

To set it up, either set up `YABEDA_RAILS_APDEX_TARGET` environment variable or use one of other methods supported by [anyway_config](https://github.com/palkan/anyway_config) gem:

```sh
YABEDA_RAILS_APDEX_TARGET=0.5 rails server
```

After this, `rails_apdex_target` metric will be reported.

In Prometheus it will be called `rails_apdex_target_seconds`:

```
rails_apdex_target_seconds{} 0.5
```