### PR TITLE
Do not merge controller back in

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -51,7 +51,8 @@ module Yabeda
               status: event.payload[:status],
               format: event.payload[:format],
               method: event.payload[:method].downcase,
-            }.merge!(event.payload.slice(*Yabeda.default_tags.keys))
+            }
+            labels.merge!(event.payload.slice(*Yabeda.default_tags.keys - labels.keys))
 
             rails_requests_total.increment(labels)
             rails_request_duration.measure(labels, Yabeda::Rails.ms2s(event.duration))


### PR DESCRIPTION
If a user defines a `default_tag :controller, nil`, then it cause the metrics to use `event.payload[:controller]` which is `"ApplicationController"` instead of `"application"`.