### PR TITLE
Minimise dependencies

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "yabeda"
-require "rails"
+require "active_support"
+require "rails/railtie"
 require "yabeda/rails/railtie"
 
 module Yabeda

--- a/yabeda-rails.gemspec
+++ b/yabeda-rails.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "rails"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "railties"
   spec.add_dependency "yabeda", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Depend only on railties and activesupport to avoid loading all of Rails. This avoids including potentially extra dependencies in application bundles when installing yabeda-rails.