### PR TITLE
Status codes for unhandled exceptions

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -58,7 +58,7 @@ module Yabeda
             labels = {
               controller: event.payload[:params]["controller"],
               action: event.payload[:params]["action"],
-              status: event.payload[:status],
+              status: Yabeda::Rails.event_status_code(event),
               format: event.payload[:format],
               method: event.payload[:method].downcase,
             }
@@ -79,6 +79,14 @@ module Yabeda
 
       def ms2s(milliseconds)
         (milliseconds.to_f / 1000).round(3)
+      end
+
+      def event_status_code(event)
+        if event.payload[:status].nil? && event.payload[:exception].present?
+          ActionDispatch::ExceptionWrapper.status_code_for_exception(event.payload[:exception].first)
+        else
+          event.payload[:status]
+        end
       end
     end
   end

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -13,6 +13,7 @@ class TestApplication < Rails::Application
   routes.append do
     get "/hello/world" => "hello#world"
     get "/hello/long" => "hello#long"
+    get "/hello/internal_server_error" => "hello#internal_server_error"
   end
 end
 
@@ -24,6 +25,10 @@ class HelloController < ActionController::API
   def long
     sleep(0.01)
     render json: { good: :morning }
+  end
+
+  def internal_server_error
+    raise StandardError
   end
 end
 

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe Yabeda::Rails, type: :integration do
       .with_tags(controller: "hello", action: "long", status: 200, method: "get", format: :html)
       .with(be_between(0.005, 0.05))
   end
+
+  it "returns internal_server_error status code" do
+    expect { get "/hello/internal_server_error" }.to \
+      increment_yabeda_counter(Yabeda.rails.requests_total)
+      .with_tags(controller: "hello", action: "internal_server_error", status: 500, method: "get", format: :html)
+  end
 end


### PR DESCRIPTION
Encounted that **Grafana** did't show all status codes by requests as it should be. And the reason was that logs saved without no statuses if an exception was not handled properly, e.g.
```ruby
{
  controller: "api/hello",
  action: "world",
  status: nil,
  format: :json,
  method: "get",
}
```

Some [exceptions]( https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L7-L22) which will be handle automatically and codes. And example how it [was made](https://github.com/rails/rails/blob/7-0-stable/actionpack/lib/action_controller/metal/instrumentation.rb#L66-L77) in **Rails 7**.
