### PR TITLE
Controller name case

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -59,11 +59,11 @@ module Yabeda
             labels = {
               controller: event.controller,
               action: event.payload[:params]["action"],
-              status: Yabeda::Rails.event_status_code(event),
+              status: event.status_code,
               format: event.payload[:format],
               method: event.payload[:method].downcase,
             }
-            puts labels
+
             labels.merge!(event.payload.slice(*Yabeda.default_tags.keys - labels.keys))
 
             rails_requests_total.increment(labels)
@@ -85,14 +85,6 @@ module Yabeda
 
       def ms2s(milliseconds)
         (milliseconds.to_f / 1000).round(3)
-      end
-
-      def event_status_code(event)
-        if event.payload[:status].nil? && event.payload[:exception].present?
-          ActionDispatch::ExceptionWrapper.status_code_for_exception(event.payload[:exception].first)
-        else
-          event.payload[:status]
-        end
       end
     end
   end

--- a/lib/yabeda/rails/config.rb
+++ b/lib/yabeda/rails/config.rb
@@ -8,6 +8,7 @@ module Yabeda
       config_name :yabeda_rails
 
       attr_config :apdex_target
+      attr_config controller_name_case: :snake
     end
   end
 end

--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -11,6 +11,14 @@ module Yabeda
           payload[:controller]
         end
       end
+
+      def status_code
+        if payload[:status].nil? && payload[:exception].present?
+          ActionDispatch::ExceptionWrapper.status_code_for_exception(payload[:exception].first)
+        else
+          payload[:status]
+        end
+      end
     end
   end
 end

--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -3,6 +3,33 @@
 module Yabeda
   module Rails
     class Event < ActiveSupport::Notifications::Event
+      def labels
+        @labels ||= begin
+          labels = {
+            controller: controller,
+            action: action,
+            status: status,
+            format: format,
+            method: method,
+          }
+          labels.merge(payload.slice(*Yabeda.default_tags.keys - labels.keys))
+        end
+      end
+
+      def duration
+        ms2s super
+      end
+
+      def view_runtime
+        ms2s payload[:view_runtime]
+      end
+
+      def db_runtime
+        ms2s payload[:db_runtime]
+      end
+
+      private
+
       def controller
         case Yabeda::Rails.config.controller_name_case
         when :snake
@@ -12,12 +39,28 @@ module Yabeda
         end
       end
 
-      def status_code
+      def action
+        payload[:action]
+      end
+
+      def status
         if payload[:status].nil? && payload[:exception].present?
           ActionDispatch::ExceptionWrapper.status_code_for_exception(payload[:exception].first)
         else
           payload[:status]
         end
+      end
+
+      def format
+        payload[:format]
+      end
+
+      def method
+        payload[:method].downcase
+      end
+
+      def ms2s(milliseconds)
+        (milliseconds.to_f / 1000).round(3)
       end
     end
   end

--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Yabeda
+  module Rails
+    class Event < ActiveSupport::Notifications::Event
+      def controller
+        case Yabeda::Rails.config.controller_name_case
+        when :snake
+          payload[:params]["controller"]
+        when :camel
+          payload[:controller]
+        end
+      end
+    end
+  end
+end

--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -32,10 +32,10 @@ module Yabeda
 
       def controller
         case Yabeda::Rails.config.controller_name_case
-        when :snake
-          payload[:params]["controller"]
         when :camel
           payload[:controller]
+        else
+          payload[:params]["controller"]
         end
       end
 

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -32,6 +32,4 @@ class HelloController < ActionController::API
   end
 end
 
-Rails.application = TestApplication
-
 TestApplication.initialize!

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -31,11 +31,14 @@ RSpec.describe Yabeda::Rails, type: :integration do
   end
 
   it "supports configuring controller name case" do
+    original_case = Yabeda::Rails.config.controller_name_case
     Yabeda::Rails.config.controller_name_case = :camel
 
     expect { get "/hello/world" }.to \
       increment_yabeda_counter(Yabeda.rails.requests_total)
       .with_tags(controller: "HelloController", action: "world", status: 200, method: "get", format: :html)
       .by(1)
+
+    Yabeda::Rails.config.controller_name_case = original_case
   end
 end

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -29,4 +29,13 @@ RSpec.describe Yabeda::Rails, type: :integration do
       increment_yabeda_counter(Yabeda.rails.requests_total)
       .with_tags(controller: "hello", action: "internal_server_error", status: 500, method: "get", format: :html)
   end
+
+  it "supports configuring controller name case" do
+    Yabeda::Rails.config.controller_name_case = :camel
+
+    expect { get "/hello/world" }.to \
+      increment_yabeda_counter(Yabeda.rails.requests_total)
+      .with_tags(controller: "HelloController", action: "world", status: 200, method: "get", format: :html)
+      .by(1)
+  end
 end

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe Yabeda::Rails, type: :integration do
   end
 
   it "supports configuring controller name case" do
-    original_case = Yabeda::Rails.config.controller_name_case
-    Yabeda::Rails.config.controller_name_case = :camel
+    original_case = described_class.config.controller_name_case
+    described_class.config.controller_name_case = :camel
 
     expect { get "/hello/world" }.to \
       increment_yabeda_counter(Yabeda.rails.requests_total)
       .with_tags(controller: "HelloController", action: "world", status: 200, method: "get", format: :html)
       .by(1)
 
-    Yabeda::Rails.config.controller_name_case = original_case
+    described_class.config.controller_name_case = original_case
   end
 end

--- a/yabeda-rails.gemspec
+++ b/yabeda-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
+  spec.add_dependency "anyway_config", ">= 1.3", "< 2.5.0"
   spec.add_dependency "railties"
   spec.add_dependency "yabeda", "~> 0.8"
 

--- a/yabeda-rails.gemspec
+++ b/yabeda-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "anyway_config", ">= 1.3", "< 2.5.0"
+  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
   spec.add_dependency "railties"
   spec.add_dependency "yabeda", "~> 0.8"
 


### PR DESCRIPTION
This allows configuration of the case of controller names in metrics.

```rb
Yabeda::Rails.config.controller_name_case = :camel

# rails_request_duration_seconds_bucket{action="show",controller="Accounts::Domains::TwoFactorAuthenticationsController",format="html",le="+Inf",method="get",status="200"} 1

Yabeda::Rails.config.controller_name_case = :snake # (default)

# rails_request_duration_seconds_bucket{action="show",controller="accounts/domains/two_factor_authentications",format="html",le="+Inf",method="get",status="200"} 1
```

This is important for us so we can correlate metrics between different systems, like logs and traces.

I introduced a new `Yabeda::Rails::Event` class to support this change, and so also extracted event-specific concerns from the long `Yabeda::Rails.install!` method into the new `Event` class.