### PR TITLE
Allow defining default_tags only for rails group

### DIFF
--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -13,7 +13,7 @@ module Yabeda
             format: format,
             method: method,
           }
-          labels.merge(payload.slice(*Yabeda.default_tags.keys - labels.keys))
+          labels.merge(payload.slice(*(Yabeda.default_tags.keys + Yabeda.rails.default_tags.keys) - labels.keys))
         end
       end
 

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -18,6 +18,12 @@ class TestApplication < Rails::Application
 end
 
 class HelloController < ActionController::API
+  def append_info_to_payload(payload)
+    super
+    payload[:custom_tag_from_rails] = "hello-world-from-rails"
+    payload[:custom_tag] = "hello-world"
+  end
+
   def world
     render json: { hello: :world }
   end

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -46,4 +46,30 @@ RSpec.describe Yabeda::Rails, type: :integration do
         .by(1)
     end
   end
+
+  context "with default_tags set" do
+    before do
+      Yabeda.default_tag :custom_tag, nil
+    end
+
+    it "increments counters for every request" do
+      expect { get "/hello/world" }.to \
+        increment_yabeda_counter(Yabeda.rails.requests_total)
+        .with_tags(custom_tag: "hello-world")
+        .by(1)
+    end
+  end
+
+  context "with ':rails' default_tags set" do
+    before do
+      Yabeda.default_tag :custom_tag_from_rails, nil, group: :rails
+    end
+
+    it "increments counters for every request" do
+      expect { get "/hello/world" }.to \
+        increment_yabeda_counter(Yabeda.rails.requests_total)
+        .with_tags(custom_tag_from_rails: "hello-world-from-rails")
+        .by(1)
+    end
+  end
 end


### PR DESCRIPTION
Currently, yabeda-rails plugin do not have into account `:rails` group default_labels when populating metrics. This change allows defining tags for :rails group, so if you are using other yabeda plugins they don't get populated with them.

The main problem here is that we are using `yabeda-rails` and `yabeda-puma` in the same application. If we set `default_tags`, both rails and puma metrics will have that tag populated. If we use the `:group` option setting it to rails (so the tag is only added to rails metrics), the plugin ignores it. This change makes rails plugin aware of `:rails` groups metrics.