### PR TITLE
Ability to customize the bucket sizing for histograms

### DIFF
--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -29,6 +29,7 @@ module Yabeda
       def install!
         Yabeda.configure do
           config = ::Yabeda::Rails.config
+          buckets = config.buckets || LONG_RUNNING_REQUEST_BUCKETS
 
           group :rails
 
@@ -37,14 +38,14 @@ module Yabeda
 
           histogram :request_duration, tags: %i[controller action status format method],
                                        unit: :seconds,
-                                       buckets: LONG_RUNNING_REQUEST_BUCKETS,
+                                       buckets: buckets,
                                        comment: "A histogram of the response latency."
 
-          histogram :view_runtime, unit: :seconds, buckets: LONG_RUNNING_REQUEST_BUCKETS,
+          histogram :view_runtime, unit: :seconds, buckets: buckets,
                                    comment: "A histogram of the view rendering time.",
                                    tags: %i[controller action status format method]
 
-          histogram :db_runtime, unit: :seconds, buckets: LONG_RUNNING_REQUEST_BUCKETS,
+          histogram :db_runtime, unit: :seconds, buckets: buckets,
                                  comment: "A histogram of the activerecord execution time.",
                                  tags: %i[controller action status format method]
 

--- a/lib/yabeda/rails/config.rb
+++ b/lib/yabeda/rails/config.rb
@@ -9,6 +9,7 @@ module Yabeda
       config_name :yabeda_rails
 
       attr_config :apdex_target
+      attr_config :buckets
       attr_config controller_name_case: :snake
     end
   end


### PR DESCRIPTION
Introduces the `buckets` configuration parameter that can override the default bucket sizing.

Resolves https://github.com/yabeda-rb/yabeda-rails/issues/31