### PR TITLE
Allow ignore_actions config to accept a proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Configuration is handled by [anyway_config] gem. With it you can load settings f
 | ---------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `apdex_target`         | integer | nil     | Tolerable time for Apdex in seconds, exposed as gauge if set.                                                                                         |
 | `controller_name_case` | symbol  | :snake  | Defines whether controller name is reported in camel case (:camel) or snake case (:snake).                                                            |
-| `ignore_actions`       | array   | []      | array of controller#action strings that should be ignored, controller should be in camel case, example `['HealthCheck::HealthCheckController#index']` |
+| `ignore_actions`       | array or proc | []      | array of controller#action strings or a proc that receives the controller#action string and returns true if the action should be ignored. Controller should be in camel case, example `['HealthCheck::HealthCheckController#index']` or `->(controller_action) { controller_action.start_with?("HealthCheck") }` |
 
 ## Development
 

--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -58,7 +58,7 @@ module Yabeda
           ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
             event = Yabeda::Rails::Event.new(*args)
 
-            next if event.controller_action.in?(config.ignore_actions)
+            next if Yabeda::Rails.ignore_action?(config.ignore_actions, event.controller_action)
 
             rails_requests_total.increment(event.labels)
             rails_request_duration.measure(event.labels, event.duration)
@@ -75,6 +75,14 @@ module Yabeda
 
       def config
         @config ||= Config.new
+      end
+
+      def ignore_action?(ignore_actions, controller_action)
+        if ignore_actions.respond_to?(:call)
+          ignore_actions.call(controller_action)
+        else
+          controller_action.in?(ignore_actions)
+        end
       end
     end
   end

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe Yabeda::Rails, type: :integration do
   context "with ignore_actions as a proc" do
     around do |example|
       original_ignore_actions = described_class.config.ignore_actions
-      described_class.config.ignore_actions = ->(controller_action) { controller_action.start_with?("HelloController#") }
+      described_class.config.ignore_actions = lambda { |controller_action|
+        controller_action.start_with?("HelloController#")
+      }
       example.call
     ensure
       described_class.config.ignore_actions = original_ignore_actions

--- a/spec/yabeda/rails_spec.rb
+++ b/spec/yabeda/rails_spec.rb
@@ -72,4 +72,19 @@ RSpec.describe Yabeda::Rails, type: :integration do
         .by(1)
     end
   end
+
+  context "with ignore_actions as a proc" do
+    around do |example|
+      original_ignore_actions = described_class.config.ignore_actions
+      described_class.config.ignore_actions = ->(controller_action) { controller_action.start_with?("HelloController#") }
+      example.call
+    ensure
+      described_class.config.ignore_actions = original_ignore_actions
+    end
+
+    it "ignores actions matching the proc" do
+      expect { get "/hello/world" }.not_to \
+        increment_yabeda_counter(Yabeda.rails.requests_total)
+    end
+  end
 end


### PR DESCRIPTION
This enables more flexible filtering patterns using methods like match or start_with? instead of only exact string matching.